### PR TITLE
Include .json files in package when installing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     ],
     keywords='',
     packages=find_packages(exclude=['venv']),
+    package_data={'tuvok': ['.tuvok.json']},
     install_requires=DEPENDENCIES,
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
We're unable to run tuvok when `pip install`'d directly from a Git URL, unless we specify the default config that comes with it in package_data.