### PR TITLE
Make Tuvok faster with jq checks

### DIFF
--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -32,7 +32,7 @@ class TestModule(object):
     def test_passes_if_module_not_git(self, caplog):
         file = 'tests/test_module/module_notgit.tf'
         with Wrap(self, [file], expect_exit=False):
-            assert ('Modules sourced from GitHub should be pinned FAIL in {}'.format(file)) not in caplog.text
+            assert ('[PASS] github_module_ref:Modules sourced from GitHub should be pinned:{}'.format(file)) in caplog.text
 
     def test_fails_if_module_has_rackspace_http_ref(self, caplog):
         file = 'tests/test_module/module_github_has_rackspace_ref.tf'
@@ -42,7 +42,7 @@ class TestModule(object):
     def test_passes_if_module_has_rackspace_ssh_ref(self, caplog):
         file = 'tests/test_module/module_git_has_rackspace_ref.tf'
         with Wrap(self, [file], expect_exit=False):
-            assert ('github_rackspace_module_use_ssh:Rackspace module references should use SSH source paths:{}'.format(file)) in caplog.text
+            assert ('[PASS] github_rackspace_module_use_ssh:Rackspace module references should use SSH source paths:{}'.format(file)) in caplog.text
 
     def test_warns_if_module_has_http_ref(self, caplog):
         file = 'tests/test_module/module_github_hasref.tf'

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -12,24 +12,24 @@ class TestModule(object):
     def test_warns_if_module_isnt_pinned_git(self, caplog):
         file = 'tests/test_module/module_git_missingref.tf'
         with Wrap(self, [file], expect_exit=True):
-            assert ('Modules sourced from GitHub should be pinned FAIL in {}'.format(file)) in caplog.text
+            assert ('[FAIL] github_module_ref:Modules sourced from GitHub should be pinned:some_module'.format(file)) in caplog.text
 
     def test_passes_if_module_has_ref_git(self, caplog):
         file = 'tests/test_module/module_git_hasref.tf'
         with Wrap(self, [file], expect_exit=False):
-            assert ('Modules sourced from GitHub should be pinned PASS in {}'.format(file)) in caplog.text
+            assert ('[PASS] github_module_ref:Modules sourced from GitHub should be pinned:{}'.format(file)) in caplog.text
 
     def test_warns_if_module_isnt_pinned_github(self, caplog):
         file = 'tests/test_module/module_github_missingref.tf'
         with Wrap(self, [file], expect_exit=True):
-            assert ('Modules sourced from GitHub should be pinned FAIL in {}'.format(file)) in caplog.text
+            assert ('[FAIL] github_module_ref:Modules sourced from GitHub should be pinned:some_module:{}'.format(file)) in caplog.text
 
     def test_passes_if_module_has_ref_github(self, caplog):
         file = 'tests/test_module/module_github_hasref.tf'
         with Wrap(self, [file], expect_exit=False):
-            assert ('Modules sourced from GitHub should be pinned PASS in {}'.format(file)) in caplog.text
+            assert ('[PASS] github_module_ref:Modules sourced from GitHub should be pinned:{}'.format(file)) in caplog.text
 
     def test_passes_if_module_not_git(self, caplog):
         file = 'tests/test_module/module_notgit.tf'
         with Wrap(self, [file], expect_exit=False):
-            assert ('Modules sourced from GitHub should be pinned FAIL in {}'.format(file)) not in caplog.text
+            assert ('[FAIL] github_module_ref:Modules sourced from GitHub should be pinned:some_module:{}'.format(file)) not in caplog.text

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -12,7 +12,7 @@ class TestOutput(object):
     def test_warns_if_output_has_no_description(self, caplog):
         file = 'tests/test_output/bad/outputs.tf'
         with Wrap(self, [file], expect_exit=False):
-            assert ('Outputs should contain description FAIL in {}:foo'.format(file)) in caplog.text
+            assert ('[FAIL] output_description:Outputs should contain description:foo:{}'.format(file)) in caplog.text
 
     def test_passes_if_output_has_description(self, capsys):
         with Wrap(self, ['tests/test_output/good/outputs.tf'], expect_exit=False):

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -17,7 +17,7 @@ class TestPlugins(object):
     def test_default_null(self, caplog):
         file = 'tests/test_plugins/good'
         with Wrap(self, [file], [], expect_exit=False):
-            assert ('NullCheck-None PASS in {}'.format(file)) in caplog.text
+            assert ('[PASS] NullCheck:{}'.format(file)) in caplog.text
 
     def test_disable_null(self, caplog):
         file = 'tests/test_plugins/good'

--- a/tests/test_variable.py
+++ b/tests/test_variable.py
@@ -13,11 +13,11 @@ class TestVariable(object):
         file = 'tests/test_variable/bad/variables.tf'
 
         with Wrap(self, [file]):
-            assert ('Variables must contain description FAIL in {}:foo'.format(file)) in caplog.text
-            assert ('Variables must contain type FAIL in {}:bar'.format(file)) in caplog.text
+            assert ('[FAIL] variable_description:Variables must contain description:foo:{}'.format(file)) in caplog.text
+            assert ('[FAIL] variable_type:Variables must contain type:bar'.format(file)) in caplog.text
 
     def test_passes_if_variable_has_type_and_description(self, caplog):
         file = 'tests/test_variable/good/variables.tf'
         with Wrap(self, [file], expect_exit=False):
-            assert ('Variables must contain description PASS in {}:'.format(file)) in caplog.text
-            assert ('Variables must contain type PASS in {}:'.format(file)) in caplog.text
+            assert ('[PASS] variable_description:Variables must contain description:{}'.format(file)) in caplog.text
+            assert ('[PASS] variable_type:Variables must contain type:{}'.format(file)) in caplog.text

--- a/tuvok/checks/__init__.py
+++ b/tuvok/checks/__init__.py
@@ -1,6 +1,6 @@
 from enum import Enum
 
-from .base import BaseTuvokCheck, Severity
+from .base import BaseTuvokCheck, Severity, CheckResult
 from .jq import JqCheck
 from .null import NullCheck
 

--- a/tuvok/checks/base.py
+++ b/tuvok/checks/base.py
@@ -18,9 +18,10 @@ class Severity(Enum):
 
 class CheckResult(metaclass=abc.ABCMeta):
 
-    def __init__(self, success=True, explanation=[]):
+    def __init__(self, success=True, explanation=[], check=None):
         self.explanation = []
         self.success = success
+        self.check = check
 
     def add_explanation(self, expl):
         self.explanation.append(expl)
@@ -33,6 +34,15 @@ class CheckResult(metaclass=abc.ABCMeta):
 
     def set_success(self, success):
         self.success = success
+
+    def get_severity(self):
+        return self.check.get_severity()
+
+    def get_name(self):
+        return self.check.get_name()
+
+    def get_description(self):
+        return self.check.get_description()
 
 
 class BaseTuvokCheck(metaclass=abc.ABCMeta):
@@ -59,7 +69,7 @@ class BaseTuvokCheck(metaclass=abc.ABCMeta):
             return self.check(path)
         except Exception as e:
             LOG.log(self.severity.value, e)
-            return CheckResult(success=False, explanation=[str(e)])
+            return CheckResult(success=False, explanation=[str(e)], check=self)
 
     @abc.abstractmethod
     def check(self, path):

--- a/tuvok/checks/base.py
+++ b/tuvok/checks/base.py
@@ -42,7 +42,7 @@ class BaseTuvokCheck(metaclass=abc.ABCMeta):
         try:
             return self.check(path)
         except Exception as e:
-            LOG.log(self.severity, e)
+            LOG.log(self.severity.value, e)
             return False
 
     @abc.abstractmethod

--- a/tuvok/checks/base.py
+++ b/tuvok/checks/base.py
@@ -18,31 +18,29 @@ class Severity(Enum):
 
 class CheckResult(metaclass=abc.ABCMeta):
 
-    def __init__(self, success=True, explanation=[], check=None):
-        self.explanation = []
+    def __init__(self, success=True, explanation=None, check=None):
         self.success = success
-        self.check = check
+        self.explanation = explanation
 
-    def add_explanation(self, expl):
-        self.explanation.append(expl)
+        # values copied from check
+        self.severity = check.get_severity()
+        self.name = check.get_name()
+        self.description = check.get_description()
 
     def get_explanation(self):
-        return None if len(self.explanation) == 0 else ','.join(self.explanation)
+        return self.explanation
 
     def get_success(self):
         return self.success
 
-    def set_success(self, success):
-        self.success = success
-
     def get_severity(self):
-        return self.check.get_severity()
+        return self.severity
 
     def get_name(self):
-        return self.check.get_name()
+        return self.name
 
     def get_description(self):
-        return self.check.get_description()
+        return self.description
 
 
 class BaseTuvokCheck(metaclass=abc.ABCMeta):
@@ -63,13 +61,6 @@ class BaseTuvokCheck(metaclass=abc.ABCMeta):
 
     def get_severity(self):
         return self.severity
-
-    def safe_check(self, path):
-        try:
-            return self.check(path)
-        except Exception as e:
-            LOG.log(self.severity.value, e)
-            return CheckResult(success=False, explanation=[str(e)], check=self)
 
     @abc.abstractmethod
     def check(self, path):

--- a/tuvok/checks/base.py
+++ b/tuvok/checks/base.py
@@ -16,6 +16,25 @@ class Severity(Enum):
     NOTSET = logging.NOTSET
 
 
+class CheckResult(metaclass=abc.ABCMeta):
+
+    def __init__(self, success=True, explanation=[]):
+        self.explanation = []
+        self.success = success
+
+    def add_explanation(self, expl):
+        self.explanation.append(expl)
+
+    def get_explanation(self):
+        return None if len(self.explanation) == 0 else ','.join(self.explanation)
+
+    def get_success(self):
+        return self.success
+
+    def set_success(self, success):
+        self.success = success
+
+
 class BaseTuvokCheck(metaclass=abc.ABCMeta):
 
     def __init__(self, name=None, description=None, severity=Severity.WARNING, prevent=False):
@@ -35,15 +54,12 @@ class BaseTuvokCheck(metaclass=abc.ABCMeta):
     def get_severity(self):
         return self.severity
 
-    def get_explanation(self):
-        return None
-
     def safe_check(self, path):
         try:
             return self.check(path)
         except Exception as e:
             LOG.log(self.severity.value, e)
-            return False
+            return CheckResult(success=False, explanation=[str(e)])
 
     @abc.abstractmethod
     def check(self, path):

--- a/tuvok/checks/builtins.py
+++ b/tuvok/checks/builtins.py
@@ -18,7 +18,7 @@ class FileLayoutCheck(BaseTuvokCheck):
 
     def check(self, path):
         parsed_json = hcl2json(path)
-        res = CheckResult(check=self)
+        results = []
 
         # output/input/variable have been put in the wrong file
         TYPES = set(['output', 'variable'])
@@ -28,9 +28,11 @@ class FileLayoutCheck(BaseTuvokCheck):
             expected_filename = '{}s.tf'.format(prefix)
 
             if len(found_top_level_objs) > 0 and actual_filename != expected_filename:
-                res.set_success(False)
                 bad_names = [','.join(list(x.keys())) for x in found_top_level_objs]
-                expl = '{}:{} was not found in a file named {}'.format(prefix, ','.join(bad_names), expected_filename)
-                res.add_explanation(expl)
+                expl = '{}:{} was not found in a file named {}:{}'.format(prefix, ','.join(bad_names), expected_filename, path)
+                results.append(CheckResult(False, expl, self))
+            else:
+                expl = ':'.join([prefix, path])
+                results.append(CheckResult(True, expl, self))
 
-        return res
+        return results

--- a/tuvok/checks/builtins.py
+++ b/tuvok/checks/builtins.py
@@ -18,7 +18,7 @@ class FileLayoutCheck(BaseTuvokCheck):
 
     def check(self, path):
         parsed_json = hcl2json(path)
-        res = CheckResult()
+        res = CheckResult(check=self)
 
         # output/input/variable have been put in the wrong file
         TYPES = set(['output', 'variable'])

--- a/tuvok/checks/builtins.py
+++ b/tuvok/checks/builtins.py
@@ -1,4 +1,4 @@
-from .base import BaseTuvokCheck, Severity
+from .base import BaseTuvokCheck, CheckResult, Severity
 from tuvok import hcl2json
 import os
 
@@ -16,13 +16,9 @@ class FileLayoutCheck(BaseTuvokCheck):
             Severity.ERROR
         )
 
-    def get_explanation(self):
-        return '\n'.join(set(self.reasons))
-
     def check(self, path):
         parsed_json = hcl2json(path)
-        self.reasons = []
-        self.failed = False
+        res = CheckResult()
 
         # output/input/variable have been put in the wrong file
         TYPES = set(['output', 'variable'])
@@ -32,9 +28,9 @@ class FileLayoutCheck(BaseTuvokCheck):
             expected_filename = '{}s.tf'.format(prefix)
 
             if len(found_top_level_objs) > 0 and actual_filename != expected_filename:
-                self.failed = True
+                res.set_success(False)
                 bad_names = [','.join(list(x.keys())) for x in found_top_level_objs]
                 expl = '{}:{} was not found in a file named {}'.format(prefix, ','.join(bad_names), expected_filename)
-                self.reasons.append(expl)
+                res.add_explanation(expl)
 
-        return not self.failed
+        return res

--- a/tuvok/checks/jq.py
+++ b/tuvok/checks/jq.py
@@ -40,7 +40,7 @@ class JqCheck(BaseTuvokCheck):
         return str(stdout)
 
     def check(self, f):
-        res = CheckResult()
+        res = CheckResult(check=self)
 
         query = 'json2hcl --reverse < {} | jq -rc {}'.format(f, translate_jq(self.jq_command))
         proc = subprocess.Popen(

--- a/tuvok/checks/jq.py
+++ b/tuvok/checks/jq.py
@@ -6,12 +6,6 @@ import subprocess
 import shlex
 
 
-def translate_jq(query):
-    if platform.system() == 'Windows':
-        return '\"{}\"'.format(query.replace('"', '\\\"'))
-    return "'{}'".format(query)
-
-
 class JqCheck(BaseTuvokCheck):
 
     jq_command = None
@@ -26,7 +20,6 @@ class JqCheck(BaseTuvokCheck):
             return ",".join(self.explanation)
         return None
 
-    # @lru_cache(maxsize=32)
     def readfile(self, f):
         content = None
         with open(os.path.abspath(f), 'r') as content_file:
@@ -34,7 +27,6 @@ class JqCheck(BaseTuvokCheck):
 
         return content
 
-    # @lru_cache(maxsize=32)
     def hcl2json(self, text):
         query = 'json2hcl --reverse'.split(' ')
 
@@ -49,12 +41,12 @@ class JqCheck(BaseTuvokCheck):
         return str(stdout)
 
     def check(self, f):
-        query = 'jq -rc {}'.format(translate_jq(self.jq_command))
+        query = ['jq','-rc', '{}'.format(self.jq_command)]
         text_hcl = self.readfile(f)
         test_json = self.hcl2json(text_hcl)
 
         proc = subprocess.Popen(
-            args=query, shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+            args=query, shell=False, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
             stderr=subprocess.PIPE, universal_newlines=True)
         (stdout, stderr) = proc.communicate(input=test_json)
 

--- a/tuvok/checks/null.py
+++ b/tuvok/checks/null.py
@@ -10,4 +10,4 @@ class NullCheck(BaseTuvokCheck):
         super().__init__()
 
     def check(self, path):
-        return CheckResult()
+        return CheckResult(check=self)

--- a/tuvok/checks/null.py
+++ b/tuvok/checks/null.py
@@ -1,4 +1,4 @@
-from .base import BaseTuvokCheck
+from .base import BaseTuvokCheck, CheckResult
 
 
 class NullCheck(BaseTuvokCheck):
@@ -10,4 +10,4 @@ class NullCheck(BaseTuvokCheck):
         super().__init__()
 
     def check(self, path):
-        return True
+        return CheckResult()

--- a/tuvok/checks/null.py
+++ b/tuvok/checks/null.py
@@ -10,4 +10,4 @@ class NullCheck(BaseTuvokCheck):
         super().__init__()
 
     def check(self, path):
-        return CheckResult(check=self)
+        return CheckResult(True,str(path),self)

--- a/tuvok/cli.py
+++ b/tuvok/cli.py
@@ -8,7 +8,7 @@ import re
 import sys
 
 from tuvok import __version__
-from tuvok.checks import Severity
+from tuvok.checks import CheckResult, Severity
 
 
 EXCLUSIONS = [r'.git', r'.terraform', r'.circleci', '__pycache__', r'*.egg-info']
@@ -162,37 +162,44 @@ def main():
                 True
             ))
 
-    LOG.info('Scanning %s files and executing checks', len(files_to_scan))
+    LOG.info('Scanning %s files and executing %s checks', len(files_to_scan), len(tuvok_checks))
 
     executor = concurrent.futures.ThreadPoolExecutor(max_workers=5)
-    results = []
+    tasks = []
     for f in files_to_scan:
         for p in tuvok_checks:
             if p.get_name() in config['ignore']:
                 continue
 
-            results.append(executor.submit(p.safe_check, f))
+            tasks.append(executor.submit(p.check, f))
 
-    error_encountered = []
-    for future in results:
-        check_result = future.result()
+    # aggregate up all the tasks, and if the results are a list, ensure we flatten
+    results = []
+    for future in tasks:
+        r = future.result()
 
+        if type(r) is list:
+            for r_i in r:
+                results.append(r_i)
+        elif type(r) is CheckResult:
+            results.append(r)
+        else:
+            raise Exception('Result of check was not a CheckResult or List')
+
+    for check_result in results:
         str_result = 'PASS' if check_result.get_success() else 'FAIL'
         sev_result = Severity.DEBUG if check_result.get_success() else check_result.get_severity()
-        error_encountered.append(sev_result)
+
+        # join everything truthy together with colons
+        str_explanation = ":".join([x for x in [check_result.get_name(), check_result.get_description(), check_result.get_explanation()] if x])
 
         LOG.log(
             sev_result.value,
-            "{}-{} {} in {}:{}".format(
-                check_result.get_name(),
-                check_result.get_description(),
-                str_result,
-                f,
-                check_result.get_explanation() or 'unknown'
-            )
+            "[{}] {}".format(str_result, str_explanation)
         )
 
-    if Severity.ERROR in error_encountered:
+    # if any checks failed, get their severity, and see if any are ERROR
+    if Severity.ERROR in [r.get_severity() for r in results if not r.get_success()]:
         LOG.info("Validation errors reported.")
         sys.exit(1)
 

--- a/tuvok/cli.py
+++ b/tuvok/cli.py
@@ -178,14 +178,14 @@ def main():
         check_result = future.result()
 
         str_result = 'PASS' if check_result.get_success() else 'FAIL'
-        sev_result = Severity.DEBUG if check_result.get_success() else p.get_severity()
+        sev_result = Severity.DEBUG if check_result.get_success() else check_result.get_severity()
         error_encountered.append(sev_result)
 
         LOG.log(
             sev_result.value,
             "{}-{} {} in {}:{}".format(
-                p.get_name(),
-                p.get_description(),
+                check_result.get_name(),
+                check_result.get_description(),
                 str_result,
                 f,
                 check_result.get_explanation() or 'unknown'


### PR DESCRIPTION
Experimenting with removing the shell here. It turns out it wasn't very helpful, as the number of processes for a large repo, Running a thread pool helped a ton, though I had to build a class to hold all the relevant results from a check, so it was easier to hand around.

Before:
```
➜  tuvok git:(master) time tuvok ~/src/test_repo -V 2>&1 | grep -v tuvok
0.00s user 0.01s system 0% cpu 23.164 total
```

After:
```
➜  tuvok git:(martinb3/faster_jq) time tuvok ~/src/test_repo -V 2>&1 | grep -v tuvok
0.00s user 0.01s system 0% cpu 8.434 total
```
