### PR TITLE
Add checks to ensure modules use SSH source paths

### DIFF
--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -33,3 +33,23 @@ class TestModule(object):
         file = 'tests/test_module/module_notgit.tf'
         with Wrap(self, [file], expect_exit=False):
             assert ('Modules sourced from GitHub should be pinned FAIL in {}'.format(file)) not in caplog.text
+
+    def test_fails_if_module_has_rackspace_http_ref(self, caplog):
+        file = 'tests/test_module/module_github_has_rackspace_ref.tf'
+        with Wrap(self, [file], expect_exit=True):
+            assert ('Rackspace module references should use SSH source paths FAIL in {}'.format(file)) in caplog.text
+
+    def test_passes_if_module_has_rackspace_ssh_ref(self, caplog):
+        file = 'tests/test_module/module_git_has_rackspace_ref.tf'
+        with Wrap(self, [file], expect_exit=False):
+            assert ('Rackspace module references should use SSH source paths PASS in {}'.format(file)) in caplog.text
+
+    def test_warns_if_module_has_http_ref(self, caplog):
+        file = 'tests/test_module/module_github_hasref.tf'
+        with Wrap(self, [file], expect_exit=False):
+            assert ('Module references should use SSH source paths FAIL in {}'.format(file)) in caplog.text
+
+    def test_passes_if_module_has_ssh_ref(self, caplog):
+        file = 'tests/test_module/module_git_hasref.tf'
+        with Wrap(self, [file], expect_exit=False):
+            assert ('Module references should use SSH source paths PASS in {}'.format(file)) in caplog.text

--- a/tests/test_module/module_git_has_rackspace_ref.tf
+++ b/tests/test_module/module_git_has_rackspace_ref.tf
@@ -1,0 +1,3 @@
+module "some_module" {
+  source = "git@github.com:rackspace-infrastructure-automation/test//modules//terraform?ref=v1.2.3"
+}

--- a/tests/test_module/module_github_has_rackspace_ref.tf
+++ b/tests/test_module/module_github_has_rackspace_ref.tf
@@ -1,0 +1,3 @@
+module "some_module" {
+  source = "github.com/rackspace-infrastructure-automation/test//modules//terraform?ref=v1.2.3"
+}

--- a/tuvok/.tuvok.json
+++ b/tuvok/.tuvok.json
@@ -27,6 +27,20 @@
       "type": "jq",
       "jq": ".module[] | { _module_name: . | keys[], _data: .[] } | select((._data[].source != null) and ((._data[].source | startswith(\"git@\")) or (._data[].source | startswith(\"github.com/\"))) and (._data[].source | contains(\"ref=\") | not)) | ._module_name",
       "prevent_override": false
+    },
+    "github_rackspace_module_use_ssh": {
+      "description": "Rackspace module references should use SSH source paths",
+      "severity": "ERROR",
+      "type": "jq",
+      "jq": ".module[] | { _module_name: . | keys[], _data: .[] } | select((._data[].source != null) and (._data[].source | startswith(\"github.com/rackspace-infrastructure-automation\"))) | ._module_name",
+      "prevent_override": true
+    },
+    "github_module_use_ssh": {
+      "description": "Module references should use SSH source paths",
+      "severity": "WARNING",
+      "type": "jq",
+      "jq": ".module[] | { _module_name: . | keys[], _data: .[] } | select((._data[].source != null) and (._data[].source | startswith(\"github.com/\")) and (._data[].source | startswith(\"github.com/rackspace-infrastructure-automation\") | not)) | ._module_name",
+      "prevent_override": false
     }
   },
   "ignore": []


### PR DESCRIPTION
##### Rules or Functionality Affected
New rules to verify module source references use SSH source paths.

##### Corresponding Issue

##### Pull Request Summary
Add rules to verify module source lines use SSH source paths when referencing github.com.  Source paths located in the `rackspace-infrastructure-automation` organization will fail if not using SSH.  Source paths to other GitHub locations will only warn if not using SSH.
##### Note to the PR authors about closing issues

Only close the issue if you believe that the issue is fully resolved with this PR. Depending on the way this pull request has referenced the corresponding issue, the issue may be automatically closed. If you feel the issue is not resolved please reopen the issue.
