### PR TITLE
update python and fix docker version and issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /app
     docker:
-      - image: docker:18.06.1-ce-git
+      - image: docker:18.06.3-ce-git
     steps:
       - checkout
       - setup_remote_docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV PATH="/root/.local/bin:${PATH}"
 
 # Install packages/updates/dependencies
 RUN wget -q https://github.com/kvz/json2hcl/releases/download/v0.0.6/json2hcl_v0.0.6_linux_amd64 -O /usr/local/bin/json2hcl && chmod +x /usr/local/bin/json2hcl
-RUN apk --update add git openssh curl jq
+RUN apk --update add git openssh curl jq gcc build-base
 
 ADD . /tuvok
 WORKDIR /tuvok

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
     license=__license__,
     classifiers=[
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7'
     ],
     keywords='',
     packages=find_packages(exclude=['venv']),

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,style
+envlist = py37,style
 skipsdist = TRUE
 
 [testenv]
@@ -9,7 +9,7 @@ commands=
     python -c "import sys;print('\nPYTHON VERSION\n%s\n' % sys.version)"
 
 [testenv:style]
-basepython = python3.6
+basepython = python3.7
 commands =
     flake8 sftrescue --statistics
 


### PR DESCRIPTION
##### Rules or Functionality Affected
- Docker image had updated as it was not pinned to a version. This caused issues with pytest/pylint due to asteroid requirements with GCC.
- Python version 3.7 is fairly standard now so updating to that.

##### Corresponding Issue
N/A
##### Pull Request Summary
- Updated to python 3.7 in tests. Still allowing 3.6 
- Updated docker container version to latest. 
- Fixed issues with current/latest docker install due to pylint/pytest changes
##### Note to the PR authors about closing issues

Only close the issue if you believe that the issue is fully resolved with this PR. Depending on the way this pull request has referenced the corresponding issue, the issue may be automatically closed. If you feel the issue is not resolved please reopen the issue.
