### PR TITLE
HCL2 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,7 @@ venv.bak/
 .mypy_cache/
 .dmypy.json
 dmypy.json
+
+# VSCode
+
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,13 @@ LABEL maintainer="Rackspace"
 ENV PATH="/root/.local/bin:${PATH}"
 
 # Install packages/updates/dependencies
-RUN wget -q https://github.com/kvz/json2hcl/releases/download/v0.0.6/json2hcl_v0.0.6_linux_amd64 -O /usr/local/bin/json2hcl && chmod +x /usr/local/bin/json2hcl
 RUN apk --update add git openssh curl jq gcc build-base
 
 ADD . /tuvok
 WORKDIR /tuvok
-RUN pip3 install --user -r test-requirements.txt -r requirements.txt -e .
+RUN pip3 install --user -r test-requirements.txt
+RUN pip3 install --user -r requirements.txt
+RUN pip3 install --user -e .
 
 WORKDIR /root
 ENTRYPOINT [ "/bin/sh", "-c" ]

--- a/README.md
+++ b/README.md
@@ -57,6 +57,35 @@ $ docker run local/tuvok:latest -c "cd /tuvok && pytest -q"
 17 passed in 9.61 seconds
 ```
 
+### Custom configuration files
+
+Tuvok supports custom configuration rules, allowing the creation of additional rules, or overriding the behavior of existing rules.  The tool will load and merge configurations from any explicitly provided configuration file, or from any file named `.tuvok.json` in a scanned directory.  Currently, only jq based checks can be included in the custom configuration.  An example custom configuration file can be found below:
+
+```JSON
+{
+  "checks": {
+    "my_custom_check": {
+      "description": "My Custom Check description",
+      "severity": "ERROR",
+      "type": "jq",
+      "jq": ".module[] | keys[] | select(match(\"[A-Z-]\"))",
+      "prevent_override": false
+    }
+  },
+  "ignore": ["variable_type"]
+}
+```
+
+- `checks` - A mapping of jq based configuration checks.  Existing checks can be overridden, and additional checks can be added.  Each check should be given a unique name.  Each check has the following properties.  These properties are optional when overriding an existing check, and required for additional checks:
+  - `description` - A basic description of the configuration check
+  - `severity` - The severity level of the check.  Allowed values include `INFO`, `WARNING`, & `ERROR`
+  - `type` - The type of the configuration check.  Allowed values include `jq`
+  - `jq` - The jq query string that matches test failures. (I.E. the example check will match any module with a logical name that includes upper case letters or dashes.)
+  - `prevent_override` - A boolean flag that prevents other custom configurations from modifying the check.
+- `ignore` - A list of check names that should be skipped by the tool when evaluating a file.
+
+*NOTE:* The generated json format of files changed with version 0.1.0 of the tool when HCL2 support was added.  If custom config reules were created prior to this version, JQ query strings should be tested and updated as necessary.
+
 ## How to propose new rules
 
 Please see the [contributing guidelines](docs/CONTRIBUTING.md) for general information on contributing to this project. The process for proposing additional rules, modifying existing rules, or removing/deprecating rules will be followed like any other contribution.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+python-hcl2

--- a/tests/test_hcl2.py
+++ b/tests/test_hcl2.py
@@ -1,0 +1,26 @@
+from tuvok import cli
+from helpers.wrap import Wrap
+
+
+class TestHcl2(object):
+    def setup(self):
+        self.main = cli.main
+
+    def teardown(self):
+        self.main = None
+
+    def test_good_hcl2(self, caplog):
+        file = 'tests/test_hcl2/good'
+        with Wrap(self, [file], [], expect_exit=False):
+            assert 'FAIL' not in caplog.text
+            assert 'variable:foo was not found in a file named variables.tf' not in caplog.text
+            assert 'output:foo was not found in a file named outputs.tf' not in caplog.text
+            assert 'github_module_ref:Modules sourced from GitHub should be pinned:some_module:' not in caplog.text
+
+    def test_bad_hcl2(self, caplog):
+        file = 'tests/test_hcl2/bad'
+        with Wrap(self, [file], [], expect_exit=True):
+            assert 'FAIL' in caplog.text
+            assert 'variable:foo was not found in a file named variables.tf' in caplog.text
+            assert 'output:foo was not found in a file named outputs.tf' in caplog.text
+            assert 'github_module_ref:Modules sourced from GitHub should be pinned:some_module:' in caplog.text

--- a/tests/test_hcl2/bad/main.tf
+++ b/tests/test_hcl2/bad/main.tf
@@ -1,0 +1,95 @@
+
+terraform {
+  required_version = ">= 0.12"
+}
+
+resource "aws_iam_role" "role1" {
+  name = join("-", [var.foo, "role1"])
+
+  assume_role_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+    {
+        "Action": "sts:AssumeRole",
+        "Principal": {
+        "Service": "ec2.amazonaws.com"
+        },
+        "Effect": "Allow",
+        "Sid": ""
+    }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_role" "role2" {
+  name = join("-", [var.foo, "role2"])
+
+  assume_role_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+    {
+        "Action": "sts:AssumeRole",
+        "Principal": {
+        "Service": "ec2.amazonaws.com"
+        },
+        "Effect": "Allow",
+        "Sid": ""
+    }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_policy" "policy" {
+  name        = var.foo
+  description = "A test policy"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "ec2:Describe*"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+locals {
+  resource_map = {
+    resource1 = aws_iam_role.role1.name
+    resource2 = aws_iam_role.role2.name
+  }
+}
+
+
+resource "aws_iam_role_policy_attachment" "test-attach" {
+  for_each = local.resource_map
+
+  role       = each.value
+  policy_arn = aws_iam_policy.policy.arn
+}
+
+module "some_module" {
+  source = "git@github.com:rackspace-infrastructure-automation/test//modules/terraform"
+
+  param1 = "some_string"
+  param2 = 1234
+  param3 = true
+  param4 = ["some_other_string", 5678, false]
+
+  param5 = {
+    subparam1 = "one more string"
+    subparam2 = 9876
+  }
+
+  param7 = aws_iam_policy.role.name
+}

--- a/tests/test_hcl2/bad/outputs.tf
+++ b/tests/test_hcl2/bad/outputs.tf
@@ -1,0 +1,4 @@
+variable "foo" {
+  description = "I am a valid variable block, but in the wrong file!"
+  type        = string
+}

--- a/tests/test_hcl2/bad/variables.tf
+++ b/tests/test_hcl2/bad/variables.tf
@@ -1,0 +1,4 @@
+output "foo" {
+  description = "I am a valid output block, but in the wrong file!"
+  value       = aws_iam_role.role1.name
+}

--- a/tests/test_hcl2/good/main.tf
+++ b/tests/test_hcl2/good/main.tf
@@ -1,0 +1,96 @@
+
+terraform {
+  required_version = ">= 0.12"
+}
+
+resource "aws_iam_role" "role1" {
+  name = join("-", [var.foo, "role1"])
+
+  assume_role_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+    {
+        "Action": "sts:AssumeRole",
+        "Principal": {
+        "Service": "ec2.amazonaws.com"
+        },
+        "Effect": "Allow",
+        "Sid": ""
+    }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_role" "role2" {
+  name = join("-", [var.foo, "role2"])
+
+  assume_role_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+    {
+        "Action": "sts:AssumeRole",
+        "Principal": {
+        "Service": "ec2.amazonaws.com"
+        },
+        "Effect": "Allow",
+        "Sid": ""
+    }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_policy" "policy" {
+  name        = var.foo
+  description = "A test policy"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "ec2:Describe*"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+locals {
+  resource_map = {
+    resource1 = aws_iam_role.role1.name
+    resource2 = aws_iam_role.role2.name
+  }
+}
+
+
+resource "aws_iam_role_policy_attachment" "test-attach" {
+  for_each = local.resource_map
+
+  role       = each.value
+  policy_arn = aws_iam_policy.policy.arn
+}
+
+
+module "some_module" {
+  source  = "git@github.com:rackspace-infrastructure-automation/test//modules/terraform?ref=v1.2.3"
+
+  param1 = "some_string"
+  param2 = 1234
+  param3 = true
+  param4 = ["some_other_string", 5678, false, aws_iam_role2.name]
+
+  param5 = {
+    subparam1 = "one more string"
+    subparam2 = 9876
+  }
+
+  param7 = aws_iam_policy.role1.name
+}

--- a/tests/test_hcl2/good/outputs.tf
+++ b/tests/test_hcl2/good/outputs.tf
@@ -1,0 +1,4 @@
+output "foo" {
+  description = "I am a valid output block!"
+  value       = aws_iam_role.role1.name
+}

--- a/tests/test_hcl2/good/variables.tf
+++ b/tests/test_hcl2/good/variables.tf
@@ -1,0 +1,4 @@
+variable "foo" {
+  description = "I am a valid variable block!"
+  type        = string
+}

--- a/tuvok/.tuvok.json
+++ b/tuvok/.tuvok.json
@@ -4,42 +4,42 @@
       "description": "Variables must contain description",
       "severity": "ERROR",
       "type": "jq",
-      "jq": ".variable[] | {_variable_name: . | keys[], _data: .[]} | select(._data[].description == null) | ._variable_name",
+      "jq": ".variable[] | {_variable_name: . | keys[], _data: .[]} | select(._data.description == null) | ._variable_name",
       "prevent_override": true
     },
     "variable_type": {
       "description": "Variables must contain type",
       "severity": "ERROR",
       "type": "jq",
-      "jq": ".variable[] | {_variable_name: . | keys[], _data: .[]} | select(._data[].type == null) | ._variable_name",
+      "jq": ".variable[] | {_variable_name: . | keys[], _data: .[]} | select(._data.type == null) | ._variable_name",
       "prevent_override": false
     },
     "output_description": {
       "description": "Outputs should contain description",
       "severity": "WARNING",
       "type": "jq",
-      "jq": ".output[] | {_output_name: . | keys[], _data: .[]} | select(._data[].description == null) | ._output_name",
+      "jq": ".output[] | {_output_name: . | keys[], _data: .[]} | select(._data.description == null) | ._output_name",
       "prevent_override": false
     },
     "github_module_ref": {
       "description": "Modules sourced from GitHub should be pinned",
       "severity": "ERROR",
       "type": "jq",
-      "jq": ".module[] | { _module_name: . | keys[], _data: .[] } | select((._data[].source != null) and ((._data[].source | startswith(\"git@\")) or (._data[].source | startswith(\"github.com/\"))) and (._data[].source | contains(\"ref=\") | not)) | ._module_name",
+      "jq": ".module[] | { _module_name: . | keys[], _data: .[] } | select((._data.source != null) and ((._data.source[] | startswith(\"git@\")) or (._data.source[] | startswith(\"github.com/\"))) and (._data.source[] | contains(\"ref=\") | not)) | ._module_name",
       "prevent_override": false
     },
     "github_rackspace_module_use_ssh": {
       "description": "Rackspace module references should use SSH source paths",
       "severity": "ERROR",
       "type": "jq",
-      "jq": ".module[] | { _module_name: . | keys[], _data: .[] } | select((._data[].source != null) and (._data[].source | startswith(\"github.com/rackspace-infrastructure-automation\"))) | ._module_name",
+      "jq": ".module[] | { _module_name: . | keys[], _data: .[] } | select((._data.source != null) and (._data.source[] | startswith(\"github.com/rackspace-infrastructure-automation\"))) | ._module_name",
       "prevent_override": true
     },
     "github_module_use_ssh": {
       "description": "Module references should use SSH source paths",
       "severity": "WARNING",
       "type": "jq",
-      "jq": ".module[] | { _module_name: . | keys[], _data: .[] } | select((._data[].source != null) and (._data[].source | startswith(\"github.com/\")) and (._data[].source | startswith(\"github.com/rackspace-infrastructure-automation\") | not)) | ._module_name",
+      "jq": ".module[] | { _module_name: . | keys[], _data: .[] } | select((._data.source != null) and (._data.source[] | startswith(\"github.com/\")) and (._data.source[] | startswith(\"github.com/rackspace-infrastructure-automation\") | not)) | ._module_name",
       "prevent_override": false
     }
   },

--- a/tuvok/__init__.py
+++ b/tuvok/__init__.py
@@ -18,18 +18,17 @@ __license__ = 'Apache 2.0'
 __copyright__ = 'Copyright Rackspace US, Inc. 2018'
 
 
-import logging
+import hcl2
 import importlib
 import inspect
+import logging
 import pkgutil
-import os
-import subprocess
-import json
 
 import tuvok.plugins
 
 
 LOG = logging.getLogger()
+JSON_CACHE = {}
 
 
 def iter_namespace(ns_pkg):
@@ -41,15 +40,10 @@ def not_abstract_class(o):
 
 
 def hcl2json(f):
-    query = 'json2hcl --reverse < {}'.format(os.path.abspath(f))
-    proc = subprocess.Popen(
-        query, shell=True, stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE, universal_newlines=True)
-    (stdout, stderr) = proc.communicate()
-
-    if proc.returncode > 0:
-        raise Exception(str(stderr))
-    return json.loads(str(stdout))
+    if f not in JSON_CACHE:
+        with(open(f, 'r')) as file:
+            JSON_CACHE[f] = hcl2.load(file)
+    return JSON_CACHE[f]
 
 
 plugin_modules = [

--- a/tuvok/checks/jq.py
+++ b/tuvok/checks/jq.py
@@ -1,7 +1,8 @@
-from .base import BaseTuvokCheck, CheckResult
-
-import os
+import json
 import subprocess
+
+from tuvok import hcl2json
+from tuvok.checks.base import BaseTuvokCheck, CheckResult
 
 
 def translate_jq(query):
@@ -19,34 +20,15 @@ class JqCheck(BaseTuvokCheck):
         super().__init__(name, description, severity, prevent)
         self.jq_command = command
 
-    def readfile(self, f):
-        content = None
-        with open(os.path.abspath(f), 'r') as content_file:
-            content = content_file.read()
-
-        return content
-
-    def hcl2json(self, text):
-        query = 'json2hcl --reverse'.split(' ')
-
-        proc = subprocess.Popen(
-            args=query, shell=False, stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE, stdin=subprocess.PIPE, universal_newlines=True)
-        (stdout, stderr) = proc.communicate(input=text)
-
-        if proc.returncode > 0:
-            raise Exception(str(stderr))
-
-        return str(stdout)
-
     def check(self, f):
-        query = 'json2hcl --reverse < {} | jq -rc {}'.format(f, translate_jq(self.jq_command))
+        parsed_json = json.dumps(hcl2json(f))
+        query = "jq -r -c {}".format(translate_jq(self.jq_command))
         proc = subprocess.Popen(
-            args=query, shell=True, stdout=subprocess.PIPE,
+            args=query, shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
             stderr=subprocess.PIPE, universal_newlines=True)
-        (stdout, stderr) = proc.communicate()
+        (stdout, stderr) = proc.communicate(input=parsed_json)
 
-        if 'Cannot iterate over null' in stderr or stdout is '':
+        if 'Cannot iterate over null' in stderr or stdout == '':
             # nothing was found! pass, no JQ matches
             return CheckResult(True, str(f), self)
 

--- a/tuvok/cli.py
+++ b/tuvok/cli.py
@@ -7,7 +7,7 @@ import platform
 import re
 import sys
 
-from tuvok import __version__
+from tuvok import __version__, hcl2json
 from tuvok.checks import CheckResult, Severity
 
 
@@ -46,8 +46,8 @@ def load_config(file, merge=None):
                 merge['checks'][key] = value
         for rule in config.get('ignore', []):
             if rule in merge['checks'] and merge['checks'][rule].get('prevent_override', False):
-                    LOG.error("Cannot ignore check {} in Configuration file {}".format(rule, file))
-                    sys.exit(2)
+                LOG.error("Cannot ignore check {} in Configuration file {}".format(rule, file))
+                sys.exit(2)
             if rule not in merge['ignore']:
                 LOG.info("Rule {} will be ignored by custom config {}".format(rule, file))
                 merge['ignore'].append(rule)
@@ -169,6 +169,7 @@ def main():
     executor = concurrent.futures.ThreadPoolExecutor(max_workers=5)
     tasks = []
     for f in files_to_scan:
+        hcl2json(f)  # Perform initial json conversion for file and cache results
         for p in tuvok_checks:
             if p.get_name() in config['ignore']:
                 continue


### PR DESCRIPTION
##### Rules or Functionality Affected
Adds support for Terraform  files using HCL2 formatting.

##### Corresponding Issue

##### Pull Request Summary
- Support implemented by replacing use of `json2hcl` tool with `python-hcl2`
- `python-hcl2` is a native python module which allows us to access the converted HCL file directly instead of via shell commands.  It also allows us to cache the converted files, eliminating the need to convert multiple times.
- `python-hcl2` does use a slightly different generated json format, so jq rules were updated to match the new formatting.

ref: https://github.com/amplify-education/python-hcl2
##### Note to the PR authors about closing issues

Only close the issue if you believe that the issue is fully resolved with this PR. Depending on the way this pull request has referenced the corresponding issue, the issue may be automatically closed. If you feel the issue is not resolved please reopen the issue.
