### PR TITLE
Update formatting of list-plugins switch

### DIFF
--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -9,10 +9,37 @@ class TestPlugins(object):
     def teardown(self):
         self.main = None
 
-    def test_list_plugins(self, caplog):
+    def test_list_plugins(self, capsys):
         file = '--list-plugins'
+        expected_checks = [
+            {
+                'check': 'FileLayoutCheck:FileLayoutCheck',
+                'severity': 'ERROR',
+                'description': 'Ensure variables and outputs are only in files of the same name',
+            },
+            {
+                'check': 'NullCheck:NullCheck',
+                'severity': 'WARNING',
+                'description': 'None',
+            },
+            {
+                'check': 'JqCheck:variable_description',
+                'severity': 'ERROR',
+                'description': 'Variables must contain description',
+            },
+            {
+                'check': 'JqCheck:output_description',
+                'severity': 'WARNING',
+                'description': 'Outputs should contain description',
+            },
+        ]
+
         with Wrap(self, [file], [], expect_exit=False):
-            assert 'tuvok.plugins.null.NullPlugin' in caplog.text
+            out, err = capsys.readouterr()
+            for plugin in ['BuiltinPlugin', 'NullPlugin']:
+                assert plugin in out
+            for check in expected_checks:
+                assert "[Severity.{severity}] {check}\n\t{description}".format(**check) in out
 
     def test_default_null(self, caplog):
         file = 'tests/test_plugins/good'

--- a/tuvok/checks/base.py
+++ b/tuvok/checks/base.py
@@ -56,6 +56,9 @@ class BaseTuvokCheck(metaclass=abc.ABCMeta):
     def get_name(self):
         return self.name
 
+    def get_type(self):
+        return self.__class__.__name__
+
     def get_description(self):
         return self.description
 


### PR DESCRIPTION
Making some formatting changes to the `--list-plugins` switch to get a bit more detail and to include the jq checks loaded from the various config files..  

###### Original output
```
> tuvok --list-plugins
WARNING:tuvok:Loaded plugins: [<class 'tuvok.plugins.builtins.BuiltinPlugin'>, <class 'tuvok.plugins.null.NullPlugin'>]
WARNING:tuvok:Loaded checks: [<tuvok.checks.builtins.FileLayoutCheck object at 0x00000221FB69C898>, <tuvok.checks.null.NullCheck object at 0x00000221FB6BAAC8>]
```

###### Updated output
```
> tuvok --list-plugins
Loaded plugins: BuiltinPlugin, NullPlugin

Loaded checks:

[Severity.ERROR] FileLayoutCheck:FileLayoutCheck
        Ensure variables and outputs are only in files of the same name
[Severity.WARNING] NullCheck:NullCheck
        None
[Severity.ERROR] JqCheck:variable_description
        Variables must contain description
[Severity.ERROR] JqCheck:variable_type
        Variables must contain type
[Severity.WARNING] JqCheck:output_description
        Outputs should contain description
[Severity.ERROR] JqCheck:github_module_ref
        Modules sourced from GitHub should be pinned
[Severity.ERROR] JqCheck:github_rackspace_module_use_ssh
        Rackspace module references should use SSH source paths
[Severity.WARNING] JqCheck:github_module_use_ssh
        Module references should use SSH source paths
```