### PR TITLE
add python-hcl2 dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,39 @@
+import ast
+import re
+
+
 from setuptools import setup, find_packages
-from tuvok import __version__, __license__
 
-"""Packaging settings."""
+"""Packaging settings"""
+DEPENDENCIES = ['python-hcl2']
 
-DEPENDENCIES = []
+
+def package_metadata():
+    """Read __version__.py for package metadata without importing package"""
+
+    _version_re = re.compile(r'__version__\s+=\s+(.*)')
+    _license_re = re.compile(r'__license__\s+=\s+(.*)')
+
+    with open('tuvok/__version__.py', 'rb') as f:
+        metadata_content = f.read()
+        version = str(ast.literal_eval(_version_re.search(metadata_content.decode('utf-8')).group(1)))
+        licencia = str(ast.literal_eval(_license_re.search(metadata_content.decode('utf-8')).group(1)))
+    return {
+        'version': version,
+        'license': licencia,
+    }
+
+
+_about = package_metadata()
 
 setup(
     name='tuvok',
-    version=__version__,
+    version=_about['version'],
     description='Terraform code validation',
     url='https://github.com/rackerlabs/tuvok/',
     author='Rackers',
     author_email='',
-    license=__license__,
+    license=_about['license'],
     classifiers=[
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7'

--- a/tuvok/__init__.py
+++ b/tuvok/__init__.py
@@ -12,39 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__title__ = 'tuvok'
-__version__ = '0.1.0'
-__license__ = 'Apache 2.0'
-__copyright__ = 'Copyright Rackspace US, Inc. 2018'
-
-
-import hcl2
 import importlib
-import inspect
 import logging
-import pkgutil
+import inspect
 
 import tuvok.plugins
 
+from .__utils__ import hcl2json, iter_namespace, not_abstract_class
+from .__version__ import __version__, __title__, __copyright__, __license__
 
 LOG = logging.getLogger()
-JSON_CACHE = {}
-
-
-def iter_namespace(ns_pkg):
-    return pkgutil.iter_modules(ns_pkg.__path__, ns_pkg.__name__ + ".")
-
-
-def not_abstract_class(o):
-    return inspect.isclass(o) and not inspect.isabstract(o)
-
-
-def hcl2json(f):
-    if f not in JSON_CACHE:
-        with(open(f, 'r')) as file:
-            JSON_CACHE[f] = hcl2.load(file)
-    return JSON_CACHE[f]
-
 
 plugin_modules = [
     importlib.import_module(name)

--- a/tuvok/__utils__.py
+++ b/tuvok/__utils__.py
@@ -1,0 +1,18 @@
+import  hcl2
+import inspect
+import pkgutil
+
+JSON_CACHE = {}
+
+def hcl2json(f):
+    if f not in JSON_CACHE:
+        with(open(f, 'r')) as file:
+            JSON_CACHE[f] = hcl2.load(file)
+    return JSON_CACHE[f]
+
+def iter_namespace(ns_pkg):
+    return pkgutil.iter_modules(ns_pkg.__path__, ns_pkg.__name__ + ".")
+
+
+def not_abstract_class(o):
+    return inspect.isclass(o) and not inspect.isabstract(o)

--- a/tuvok/__version__.py
+++ b/tuvok/__version__.py
@@ -1,0 +1,5 @@
+__title__ = 'tuvok'
+__version__ = '0.1.0'
+__license__ = 'Apache 2.0'
+__copyright__ = 'Copyright Rackspace US, Inc. 2018'
+


### PR DESCRIPTION
##### Rules or Functionality Affected
n/a
##### Corresponding Issue
#36 

##### Pull Request Summary
- load version without need to load package
- move the hcl2 helper function to a separate module.  
- update dependencies for tuvok in setup.py
This combination of things let  me load tuvok.__Init__ from setup without  the chicken-egg dependency issue
