### PR TITLE
Add check to find variables with defaults

### DIFF
--- a/tests/test_plugins/good/variables.tf
+++ b/tests/test_plugins/good/variables.tf
@@ -1,5 +1,4 @@
 variable "foo" {
     description = "I am a valid variable block!"
     type = "string"
-    default = ""
 }

--- a/tests/test_variable.py
+++ b/tests/test_variable.py
@@ -14,10 +14,12 @@ class TestVariable(object):
 
         with Wrap(self, [file]):
             assert ('[FAIL] variable_description:Variables must contain description:foo:{}'.format(file)) in caplog.text
-            assert ('[FAIL] variable_type:Variables must contain type:bar'.format(file)) in caplog.text
+            assert ('[FAIL] variable_type:Variables must contain type:bar:{}'.format(file)) in caplog.text
+            assert ('[FAIL] variable_default:Variables should not contain defaults.  Values should be provided via a tfvars file:baz:{}'.format(file)) in caplog.text
 
-    def test_passes_if_variable_has_type_and_description(self, caplog):
+    def test_passes_if_variable_has_type_and_description_and_no_default(self, caplog):
         file = 'tests/test_variable/good/variables.tf'
         with Wrap(self, [file], expect_exit=False):
             assert ('[PASS] variable_description:Variables must contain description:{}'.format(file)) in caplog.text
             assert ('[PASS] variable_type:Variables must contain type:{}'.format(file)) in caplog.text
+            assert ('[PASS] variable_default:Variables should not contain defaults.  Values should be provided via a tfvars file:{}'.format(file)) in caplog.text

--- a/tests/test_variable/bad/variables.tf
+++ b/tests/test_variable/bad/variables.tf
@@ -1,9 +1,15 @@
+# A variable with no description
+
 variable "foo" {
   type    = "string"
-  default = "" # A variable with no description
 }
 
 variable "bar" {
   description = "A variable with no type."
+}
+
+variable "baz" {
+  description = "A variable with a preset default."
+  type        = "string"
   default     = ""
 }

--- a/tests/test_variable/good/variables.tf
+++ b/tests/test_variable/good/variables.tf
@@ -1,5 +1,4 @@
 variable "foo" {
     description = "I am a valid variable block!"
     type = "string"
-    default = ""
 }

--- a/tuvok/.tuvok.json
+++ b/tuvok/.tuvok.json
@@ -1,5 +1,12 @@
 {
   "checks": {
+    "variable_default": {
+      "description": "Variables should not contain defaults.  Values should be provided via a tfvars file",
+      "severity": "WARNING",
+      "type": "jq",
+      "jq": ".variable[] | {_variable_name: . | keys[], _data: .[]} | select(._data.default != null) | ._variable_name",
+      "prevent_override": false
+    },
     "variable_description": {
       "description": "Variables must contain description",
       "severity": "ERROR",


### PR DESCRIPTION
Adds additional check to find variables defined with a default value.  For customer environments, layers should define no default values for a variable, but instead provide them in tfvar files.

This rule can and should be ignored in modules using a custom config file.
