### PR TITLE
[MPSUPENG-851] Ensure versions are pinned in provider block

### DIFF
--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -20,3 +20,15 @@ class TestProvider(object):
 
         with Wrap(self, [file], expect_exit=False):
             assert ('[PASS] provider_has_region:Provider block should have region declared:{}'.format(file)) in caplog.text
+
+    def test_fails_if_version_not_in_provider_block(self, caplog):
+        file = 'tests/test_provider/bad/main.tf'
+
+        with Wrap(self, [file], expect_exit=False):
+            assert ('[FAIL] provider_has_version:Provider block should have version pinned:aws:{}'.format(file)) in caplog.text
+
+    def test_passes_if_version_in_provider_block(self, caplog):
+        file = 'tests/test_provider/good/main.tf'
+
+        with Wrap(self, [file], expect_exit=False):
+            assert ('[PASS] provider_has_version:Provider block should have version pinned:{}'.format(file)) in caplog.text

--- a/tests/test_provider/bad/main.tf
+++ b/tests/test_provider/bad/main.tf
@@ -1,3 +1,7 @@
 provider "aws" {
   version = "~> 2.1"
 }
+
+provider "aws" {
+  alias = "no_version"
+}

--- a/tuvok/.tuvok.json
+++ b/tuvok/.tuvok.json
@@ -69,6 +69,13 @@
       "type": "jq",
       "jq": ".provider[] | {_provider_name: . | keys[], _data: .[]} | select(._data.region == null) | ._provider_name",
       "prevent_override": false
+    },
+    "provider_has_version": {
+      "description": "Provider block should have version pinned",
+      "severity": "WARNING",
+      "type": "jq",
+      "jq": ".provider[] | {_provider_name: . | keys[], _data: .[]} | select(._data.version == null) | ._provider_name",
+      "prevent_override": false
     }
   },
   "ignore": []


### PR DESCRIPTION
* Added rule in Tuvok JSON for ensuring version is present in provider
* Added tests to ensure functionality
* Ensured test suites pass

##### Rules or Functionality Affected

Provider rules

##### Corresponding Issue

MPCSUPENG-851

##### Note to the PR authors about closing issues

Only close the issue if you believe that the issue is fully resolved with this PR. Depending on the way this pull request has referenced the corresponding issue, the issue may be automatically closed. If you feel the issue is not resolved please reopen the issue.
