### PR TITLE
Fix issue with region provider check

### DIFF
--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -10,7 +10,7 @@ class TestProvider(object):
         self.main = None
 
     def test_fails_if_region_not_in_provider_block(self, caplog):
-        file = 'tests/test_provider/bad/main.tf'
+        file = 'tests/test_provider/bad/no_region.tf'
 
         with Wrap(self, [file], expect_exit=False):
             assert ('[FAIL] provider_has_region:Provider block should have region declared:aws:{}'.format(file)) in caplog.text
@@ -22,7 +22,7 @@ class TestProvider(object):
             assert ('[PASS] provider_has_region:Provider block should have region declared:{}'.format(file)) in caplog.text
 
     def test_fails_if_version_not_in_provider_block(self, caplog):
-        file = 'tests/test_provider/bad/main.tf'
+        file = 'tests/test_provider/bad/no_version.tf'
 
         with Wrap(self, [file], expect_exit=False):
             assert ('[FAIL] provider_has_version:Provider block should have version pinned:aws:{}'.format(file)) in caplog.text

--- a/tests/test_provider/bad/main.tf
+++ b/tests/test_provider/bad/main.tf
@@ -1,7 +1,0 @@
-provider "aws" {
-  version = "~> 2.1"
-}
-
-provider "aws" {
-  alias = "no_version"
-}

--- a/tests/test_provider/bad/no_region.tf
+++ b/tests/test_provider/bad/no_region.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  version = "~> 2.1"
+}

--- a/tests/test_provider/bad/no_version.tf
+++ b/tests/test_provider/bad/no_version.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = "us-east-1"
+}

--- a/tests/test_provider/good/main.tf
+++ b/tests/test_provider/good/main.tf
@@ -2,3 +2,7 @@ provider "aws" {
   region  = "us-west-2"
   version = "~> 2.1"
 }
+
+provider "random" {
+  version = "~> 2.1"
+}

--- a/tuvok/.tuvok.json
+++ b/tuvok/.tuvok.json
@@ -67,7 +67,7 @@
       "description": "Provider block should have region declared",
       "severity": "WARNING",
       "type": "jq",
-      "jq": ".provider[] | {_provider_name: . | keys[], _data: .[]} | select(._data.region == null) | ._provider_name",
+      "jq": ".provider[] | select(.aws) | {_provider_name: . | keys[], _data: .[]} | select(._data.region == null) | ._provider_name",
       "prevent_override": false
     },
     "provider_has_version": {


### PR DESCRIPTION
* The region check was not restricted to aws providers causing
  providers such as random to trigger errors
* Break out provider checks into separate files to not cause
  collisions with multiple provider checks

##### Rules or Functionality Affected

##### Corresponding Issue

##### Pull Request Summary

##### Note to the PR authors about closing issues

Only close the issue if you believe that the issue is fully resolved with this PR. Depending on the way this pull request has referenced the corresponding issue, the issue may be automatically closed. If you feel the issue is not resolved please reopen the issue.
